### PR TITLE
Convert atlas property from string to pointer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Pyre type checker
+.pyre/

--- a/DUV_HotSpot.py
+++ b/DUV_HotSpot.py
@@ -14,7 +14,7 @@ class HotSpotter(bpy.types.Operator):
 
     def execute(self, context):
         #Check if an atlas object exists
-        if bpy.data.objects.get(context.scene.subrect_atlas) is None:
+        if context.scene.subrect_atlas is None:
             self.report({'WARNING'}, "No valid atlas selected!")
             return {'FINISHED'}
 

--- a/DUV_Utils.py
+++ b/DUV_Utils.py
@@ -77,7 +77,7 @@ def get_uv_ratio(context):
 
 def read_atlas(context):
     atlas = list()
-    obj = bpy.data.objects.get(context.scene.subrect_atlas)
+    obj = context.scene.subrect_atlas
     me = obj.data
     bm = bmesh.new()
     bm.from_mesh(me)

--- a/__init__.py
+++ b/__init__.py
@@ -16,7 +16,7 @@ bl_info = {
 
 if 'bpy' not in locals():
     import bpy
-    from bpy.props import EnumProperty, BoolProperty, FloatProperty
+    from bpy.props import EnumProperty, BoolProperty, FloatProperty, PointerProperty
     from . import DUV_UVTranslate, DUV_UVRotate, DUV_UVScale, DUV_UVExtend, DUV_UVStitch, DUV_UVTransfer, DUV_UVCycle, DUV_UVMirror, DUV_UVMoveToEdge,DUV_Utils,DUV_HotSpot,DUV_UVProject,DUV_UVUnwrap
 else:
     from importlib import reload
@@ -262,10 +262,10 @@ def register():
     #if prefs().adduvmenu:
     #    bpy.types.VIEW3D_MT_uv_map.prepend(uv_menu_func)
     
-    bpy.types.Scene.subrect_atlas = bpy.props.StringProperty (
-        name = "atlas",
-        default = "hotspot atlas object",
-        description = "atlas object",
+    bpy.types.Scene.subrect_atlas = bpy.props.PointerProperty (
+        name="atlas",
+        type=bpy.types.Object,
+        description="atlas object",
         )
     bpy.types.Scene.uvtransferxmin = bpy.props.FloatProperty (
         name = "uvtransferxmin",


### PR DESCRIPTION
This is a relatively minor tweak, which converts `subrect_atlas` from a `StringProperty` to a `PointerProperty`. Using a pointer property removes a level of indirection and makes it easier to query/set/update the atlas.