### PR TITLE
Fix for _PT suffix error, cleaned up naming conventions, commented some unused code

### DIFF
--- a/DUV_HotSpot.py
+++ b/DUV_HotSpot.py
@@ -6,10 +6,10 @@ from mathutils import Vector
 from . import DUV_Utils
 
 
-class HotSpotter(bpy.types.Operator):
+class DREAMUV_OT_hotspotter(bpy.types.Operator):
     """Unwrap selection using the atlas object as a guide"""
-    bl_idname = "uv.duv_hotspotter"
-    bl_label = "hotspot"
+    bl_idname = "dream_uv.hotspotter"
+    bl_label = "HotSpot"
     bl_options = {"UNDO"}
 
     def execute(self, context):

--- a/DUV_HotSpot.py
+++ b/DUV_HotSpot.py
@@ -356,15 +356,15 @@ class DREAMUV_OT_hotspotter(bpy.types.Operator):
             if aspect == 1:
                 flips = random.randint(0, 3)
                 for x in range(flips):
-                    bpy.ops.uv.duv_uvcycle()
+                    bpy.ops.dream_uv.uvcycle()
             
             #and also do randomized mirroring:
             randomMirrorX = random.randint(0, 1)
             if randomMirrorX == 1:
-                op = bpy.ops.uv.duv_uvmirror(direction = "x")
+                op = bpy.ops.dream_uv.uvmirror(direction = "x")
             randomMirrorY = random.randint(0, 1)
             if randomMirrorY == 1:
-                op = bpy.ops.uv.duv_uvmirror(direction = "y")
+                op = bpy.ops.dream_uv.uvmirror(direction = "y")
 
             
                 #now if it flipped to original position, flip it an extra time

--- a/DUV_UVCycle.py
+++ b/DUV_UVCycle.py
@@ -3,9 +3,10 @@ import math
 import bmesh
 from mathutils import Vector
 
-class UVCycle(bpy.types.Operator):
+
+class DREAMUV_OT_uv_cycle(bpy.types.Operator):
     """Rotate UVs but retain uv edge positions"""
-    bl_idname = "uv.duv_uvcycle"
+    bl_idname = "dream_uv.uvcycle"
     bl_label = "3D View UV Cycle"
     bl_options = {"UNDO"}
 

--- a/DUV_UVExtend.py
+++ b/DUV_UVExtend.py
@@ -3,9 +3,10 @@ import bmesh
 import math
 from mathutils import Vector
 
-class UVExtend(bpy.types.Operator):
+
+class DREAMUV_OT_uv_extend(bpy.types.Operator):
     """Extend UVs on selected faces from active face"""
-    bl_idname = "uv.duv_uvextend"
+    bl_idname = "dream_uv.uvextend"
     bl_label = "3D View UV Extend"
     bl_options = {"UNDO"}
 
@@ -132,5 +133,4 @@ class UVExtend(bpy.types.Operator):
             
         #bm.to_mesh(me)           
         bmesh.update_edit_mesh(mesh, False, False)
-
         return {'FINISHED'}

--- a/DUV_UVMirror.py
+++ b/DUV_UVMirror.py
@@ -3,9 +3,10 @@ import math
 import bmesh
 from mathutils import Vector
 
-class UVMirror(bpy.types.Operator):
+
+class DREAMUV_OT_uv_mirror(bpy.types.Operator):
     """Mirror UVs but retain uv edge positions"""
-    bl_idname = "uv.duv_uvmirror"
+    bl_idname = "dream_uv.uvmirror"
     bl_label = "3D View UV Mirror"
     bl_options = {"UNDO"}
 

--- a/DUV_UVMoveToEdge.py
+++ b/DUV_UVMoveToEdge.py
@@ -3,16 +3,16 @@ import math
 import bmesh
 from mathutils import Vector
 
-class UVMoveToEdge(bpy.types.Operator):
+
+class DREAMUV_OT_uv_move_to_edge(bpy.types.Operator):
     """Move Selected faces to edge of texture"""
-    bl_idname = "uv.duv_uvmovetoedge"
+    bl_idname = "dream_uv.uvmovetoedge"
     bl_label = "3D View UV Move to UV Edge"
     bl_options = {"UNDO"}
 
     direction = bpy.props.StringProperty()
 
     def execute(self, context):
-
         print(self.direction)
 
         mesh = bpy.context.object.data

--- a/DUV_UVProject.py
+++ b/DUV_UVProject.py
@@ -13,8 +13,8 @@ from mathutils import Vector
 from . import DUV_Utils
 
 
-class UVProject(bpy.types.Operator):
-    bl_idname = "duv.uvproject"
+class DREAMUV_OT_uv_project(bpy.types.Operator):
+    bl_idname = "dream_uv.uvproject"
     bl_label = "project along world axis!"
     
     def execute(self, context):
@@ -55,5 +55,4 @@ class UVProject(bpy.types.Operator):
                 loop[uv_layer].uv.y /= (ymax-ymin)
 
         bmesh.update_edit_mesh(obj.data)
-
         return {'FINISHED'}

--- a/DUV_UVRotate.py
+++ b/DUV_UVRotate.py
@@ -3,10 +3,10 @@ import bmesh
 import math
 
 
-class UVRotate(bpy.types.Operator):
+class DREAMUV_OT_uv_rotate(bpy.types.Operator):
     """Rotate UVs in the 3D Viewport"""
-    bl_idname = "uv.duv_uvrotate"
-    bl_label = "DUV UVRotate"
+    bl_idname = "dream_uv.uvrotate"
+    bl_label = "UV Rotate"
     bl_options = {"GRAB_CURSOR", "UNDO", "BLOCKING"}
 
     first_mouse_x = None
@@ -23,7 +23,6 @@ class UVRotate(bpy.types.Operator):
     rotate_snap = 45
 
     def invoke(self, context, event):
-
         #object->edit switch seems to "lock" the data. Ugly but hey it works
         bpy.ops.object.mode_set(mode='OBJECT')
         bpy.ops.object.mode_set(mode='EDIT')
@@ -151,12 +150,11 @@ class UVRotate(bpy.types.Operator):
             #update mesh
             bmesh.update_edit_mesh(self.mesh, False, False)
             return {'CANCELLED'}
-
         return {'RUNNING_MODAL'}
 
-class UVRotateStep(bpy.types.Operator):
+class DREAMUV_OT_uv_rotate_step(bpy.types.Operator):
     """Rotate UVs using snap size"""
-    bl_idname = "uv.duv_uvrotatestep"
+    bl_idname = "dream_uv.uvrotatestep"
     bl_label = "rotate"
     bl_options = {"UNDO"}
 
@@ -233,10 +231,6 @@ class UVRotateStep(bpy.types.Operator):
                 loop[uv_layer].uv.x += xcenter
                 loop[uv_layer].uv.y += ycenter
 
-
         #update mesh
         bmesh.update_edit_mesh(mesh, False, False)
-
-
-
         return {'FINISHED'}

--- a/DUV_UVScale.py
+++ b/DUV_UVScale.py
@@ -3,10 +3,10 @@ import bmesh
 import math
 
 
-class UVScale(bpy.types.Operator):
+class DREAMUV_OT_uv_scale(bpy.types.Operator):
     """Scale UVs in the 3D Viewport"""
-    bl_idname = "uv.duv_uvscale"
-    bl_label = "DUV UVScale"
+    bl_idname = "dream_uv.uvscale"
+    bl_label = "UV Scale"
     bl_options = {"GRAB_CURSOR", "UNDO", "BLOCKING"}
 
     first_mouse_x = None
@@ -30,7 +30,6 @@ class UVScale(bpy.types.Operator):
     move_snap = 2
 
     def invoke(self, context, event):
-
         #object->edit switch seems to "lock" the data. Ugly but hey it works
         bpy.ops.object.mode_set(mode='OBJECT')
         bpy.ops.object.mode_set(mode='EDIT')
@@ -97,7 +96,6 @@ class UVScale(bpy.types.Operator):
             return {'CANCELLED'}
 
     def modal(self, context, event):
-        
         if event.type == 'X':
             self.xlock=False
             self.ylock=True
@@ -209,12 +207,12 @@ class UVScale(bpy.types.Operator):
             #update mesh
             bmesh.update_edit_mesh(self.mesh, False, False)
             return {'CANCELLED'}
-
         return {'RUNNING_MODAL'}
 
-class UVScaleStep(bpy.types.Operator):
+
+class DREAMUV_OT_uv_scale_step(bpy.types.Operator):
     """Scale UVs using snap size"""
-    bl_idname = "uv.duv_uvscalestep"
+    bl_idname = "dream_uv.uvscalestep"
     bl_label = "scale"
     bl_options = {"UNDO"}
 
@@ -312,7 +310,4 @@ class UVScaleStep(bpy.types.Operator):
 
         #update mesh
         bmesh.update_edit_mesh(mesh, False, False)
-
-
-
         return {'FINISHED'}

--- a/DUV_UVStitch.py
+++ b/DUV_UVStitch.py
@@ -1,8 +1,9 @@
 import bpy
 
-class UVStitch(bpy.types.Operator):
+
+class DREAMUV_OT_uv_stitch(bpy.types.Operator):
     """Stitch shared vertices on selected faces"""
-    bl_idname = "uv.duv_uvstitch"
+    bl_idname = "dream_uv.uvstitch"
     bl_label = "3D View UV Stitch"
     bl_options = {"UNDO"}
 

--- a/DUV_UVTransfer.py
+++ b/DUV_UVTransfer.py
@@ -87,7 +87,7 @@ class DREAMUV_OT_uv_transfer(bpy.types.Operator):
 
         #cycle if needed:
         if (aspect >= 1 and aspecttarget < 1) or (aspect <= 1 and aspecttarget > 1):
-            bpy.ops.uv.duv_uvcycle()
+            bpy.ops.dream_uv.uvcycle()
         return {'FINISHED'}
 
 class DREAMUV_OT_uv_transfer_grab(bpy.types.Operator):

--- a/DUV_UVTransfer.py
+++ b/DUV_UVTransfer.py
@@ -3,13 +3,14 @@ import bmesh
 from bpy.types import Menu
 from bpy.props import EnumProperty, BoolProperty
 
-class UVTransfer(bpy.types.Operator):
-    """DUV_UVTransfer"""
-    bl_idname = "uv.duv_uvtransfer"
-    bl_label = "transfer"
+
+class DREAMUV_OT_uv_transfer(bpy.types.Operator):
+    """Transfer to selection"""
+    bl_idname = "dream_uv.uvtransfer"
+    bl_label = "UV Transfer"
     bl_options = {"UNDO"}
+
     def execute(self, context):  
-        
         bpy.ops.uv.select_split()
  
         obj = bpy.context.view_layer.objects.active
@@ -89,11 +90,12 @@ class UVTransfer(bpy.types.Operator):
             bpy.ops.uv.duv_uvcycle()
         return {'FINISHED'}
 
-class UVTransferGrab(bpy.types.Operator):
-    """DUV_UVTransferGrab"""
-    bl_idname = "uv.duv_uvtransfergrab"
-    bl_label = "transfer"
+class DREAMUV_OT_uv_transfer_grab(bpy.types.Operator):
+    """UV Transfer Grab"""
+    bl_idname = "dream_uv.uvtransfergrab"
+    bl_label = "UV Transfer Grab"
     bl_options = {"UNDO"}
+
     def execute(self, context):
         bpy.ops.uv.select_split()
  
@@ -104,8 +106,6 @@ class UVTransferGrab(bpy.types.Operator):
         faces = list()
 
         xmin,xmax,ymin,ymax=0,0,0,0
-
-        
 
         selected_uv_loops = list()
 
@@ -145,7 +145,4 @@ class UVTransferGrab(bpy.types.Operator):
         context.scene.uvtransferxmin = xmin
         context.scene.uvtransferymax = ymax
         context.scene.uvtransferymin = ymin
-
         return {'FINISHED'}
-
-        

--- a/DUV_UVTranslate.py
+++ b/DUV_UVTranslate.py
@@ -5,10 +5,10 @@ from mathutils import Vector
 from . import DUV_Utils
 
 
-class UVTranslate(bpy.types.Operator):
+class DREAMUV_OT_uv_translate(bpy.types.Operator):
     """Translate UVs in the 3D Viewport"""
-    bl_idname = "uv.duv_uvtranslate"
-    bl_label = "DUV UVTranslate"
+    bl_idname = "dream_uv.uvtranslate"
+    bl_label = "UV Translate"
     bl_options = {"GRAB_CURSOR", "UNDO", "BLOCKING"}
 
     first_mouse_x = None
@@ -238,10 +238,11 @@ class UVTranslate(bpy.types.Operator):
 
         return {'RUNNING_MODAL'}
 
-class UVTranslateStep(bpy.types.Operator):
+
+class DREAMUV_OT_uv_translate_step(bpy.types.Operator):
     """Move UVs using snap size"""
-    bl_idname = "uv.duv_uvtranslatestep"
-    bl_label = "move"
+    bl_idname = "dream_uv.uvtranslatestep"
+    bl_label = "UV Translate Step"
     bl_options = {"UNDO"}
 
     direction = bpy.props.StringProperty()
@@ -276,7 +277,4 @@ class UVTranslateStep(bpy.types.Operator):
 
         #update mesh
         bmesh.update_edit_mesh(mesh, False, False)
-
-
-
         return {'FINISHED'}

--- a/DUV_UVUnwrap.py
+++ b/DUV_UVUnwrap.py
@@ -5,9 +5,9 @@ from mathutils import Vector
 from . import DUV_Utils
 
 
-class UVUnwrapSquare(bpy.types.Operator):
+class DREAMUV_OT_uv_unwrap_square(bpy.types.Operator):
     """Unwrap and attempt to fit to a square shape"""
-    bl_idname = "uv.duv_uvunwrapsquare"
+    bl_idname = "dream_uv.uvunwrapsquare"
     bl_label = "unwrap to square shape if possible"
     
     def execute(self, context):
@@ -21,7 +21,6 @@ class UVUnwrapSquare(bpy.types.Operator):
             if face.select:
                 HSfaces.append(face)    
 
-        
         is_rect = DUV_Utils.square_fit(context)
 
         #FIT TO 0-1 range
@@ -50,5 +49,4 @@ class UVUnwrapSquare(bpy.types.Operator):
 
         bmesh.update_edit_mesh(obj.data)
         bpy.ops.mesh.select_mode(use_extend=False, use_expand=False, type='FACE')
-
         return {'FINISHED'}

--- a/DUV_Utils.py
+++ b/DUV_Utils.py
@@ -474,5 +474,3 @@ class subrect:
     posaspect = int()
     size = float()
     uvcoord = list()
-
-

--- a/__init__.py
+++ b/__init__.py
@@ -72,8 +72,8 @@ class DUVUVToolsPreferences(bpy.types.AddonPreferences):
     #adduvmenu = BoolProperty(name="Add DUV UVTools to UV Menu", default=True)
     #individualorsubmenu = EnumProperty(name="Individual or Sub-Menu", items=uvmenutype, default="SUBMENU")
 
-    def draw(self, context):
-        layout = self.layout
+    #def draw(self, context):
+        #layout = self.layout
 
         #column = layout.column(align=True)
 
@@ -85,8 +85,8 @@ class DUVUVToolsPreferences(bpy.types.AddonPreferences):
         #column.prop(self, "show_panel_tools")
         #column.prop(self, "pixel_snap")
 
-
-class DUV_UVPanel(bpy.types.Panel):
+# This should get its own py file
+class DREAMUV_PT_uv(bpy.types.Panel):
     """DreamUV Tools Panel Test!"""
     bl_label = "DreamUV"
     bl_space_type = 'VIEW_3D'
@@ -99,8 +99,8 @@ class DUV_UVPanel(bpy.types.Panel):
         prefs = bpy.context.preferences.addons[__name__].preferences
         return prefs.show_panel_tools
 
-    def draw_header(self, _):
-        layout = self.layout
+    #def draw_header(self, _):
+        #layout = self.layout
         #layout.label(text="", icon='FACESEL_HLT')
 
     def draw(self, context):
@@ -110,57 +110,57 @@ class DUV_UVPanel(bpy.types.Panel):
         col = box.column(align=True)
         col.label(text="Viewport UV Tools:")
         row = col.row(align = True)
-        row.operator("uv.duv_uvtranslate", text="Move", icon="UV_SYNC_SELECT")
+        row.operator("dream_uv.uvtranslate", text="Move", icon="UV_SYNC_SELECT")
         row = row.row(align = True)
         row.prop(addon_prefs, 'move_snap', text="")
 
         row = col.row(align = True)
-        op = row.operator("uv.duv_uvtranslatestep", text=" ", icon="TRIA_UP")
+        op = row.operator("dream_uv.uvtranslatestep", text=" ", icon="TRIA_UP")
         op.direction="up"
-        op = row.operator("uv.duv_uvtranslatestep", text=" ", icon="TRIA_DOWN")
+        op = row.operator("dream_uv.uvtranslatestep", text=" ", icon="TRIA_DOWN")
         op.direction="down"
-        op = row.operator("uv.duv_uvtranslatestep", text=" ", icon="TRIA_LEFT")
+        op = row.operator("dream_uv.uvtranslatestep", text=" ", icon="TRIA_LEFT")
         op.direction = "left"
-        op = row.operator("uv.duv_uvtranslatestep", text=" ", icon="TRIA_RIGHT")
+        op = row.operator("dream_uv.uvtranslatestep", text=" ", icon="TRIA_RIGHT")
         op.direction = "right"
         col.separator()
 
         row = col.row(align = True)
-        row.operator("uv.duv_uvscale", text="Scale", icon="FULLSCREEN_ENTER")
+        row.operator("dream_uv.uvscale", text="Scale", icon="FULLSCREEN_ENTER")
         row = row.row(align = True)
         row.prop(addon_prefs, 'scale_snap', text="")
         row = col.row(align = True)
-        op = row.operator("uv.duv_uvscalestep", text=" ", icon="ADD")
+        op = row.operator("dream_uv.uvscalestep", text=" ", icon="ADD")
         op.direction="+XY"
-        op = row.operator("uv.duv_uvscalestep", text=" ", icon="REMOVE")
+        op = row.operator("dream_uv.uvscalestep", text=" ", icon="REMOVE")
         op.direction="-XY"
-        op = row.operator("uv.duv_uvscalestep", text="+X")
+        op = row.operator("dream_uv.uvscalestep", text="+X")
         op.direction = "+X"
-        op = row.operator("uv.duv_uvscalestep", text="-X")
+        op = row.operator("dream_uv.uvscalestep", text="-X")
         op.direction = "-X"
-        op = row.operator("uv.duv_uvscalestep", text="+Y")
+        op = row.operator("dream_uv.uvscalestep", text="+Y")
         op.direction = "+Y"
-        op = row.operator("uv.duv_uvscalestep", text="-Y")
+        op = row.operator("dream_uv.uvscalestep", text="-Y")
         op.direction = "-Y"
         col.separator()
 
         row = col.row(align = True)
-        row.operator("uv.duv_uvrotate", text="Rotate", icon="FILE_REFRESH")
+        row.operator("dream_uv.uvrotate", text="Rotate", icon="FILE_REFRESH")
         row = row.row(align = True)
         row.prop(addon_prefs, 'rotate_snap', text="")
         row = col.row(align = True)
-        op = row.operator("uv.duv_uvrotatestep", text=" ", icon="LOOP_FORWARDS")
+        op = row.operator("dream_uv.uvrotatestep", text=" ", icon="LOOP_FORWARDS")
         op.direction="forward"
-        op = row.operator("uv.duv_uvrotatestep", text=" ", icon="LOOP_BACK")
+        op = row.operator("dream_uv.uvrotatestep", text=" ", icon="LOOP_BACK")
         op.direction="reverse"
         col.separator()
-        col.operator("uv.duv_uvextend", text="Extend", icon="MOD_TRIANGULATE")
-        col.operator("uv.duv_uvstitch", text="Stitch", icon="UV_EDGESEL")
-        col.operator("uv.duv_uvcycle", text="Cycle", icon="FILE_REFRESH")
+        col.operator("dream_uv.uvextend", text="Extend", icon="MOD_TRIANGULATE")
+        col.operator("dream_uv.uvstitch", text="Stitch", icon="UV_EDGESEL")
+        col.operator("dream_uv.uvcycle", text="Cycle", icon="FILE_REFRESH")
         row = col.row(align = True)
-        op = row.operator("uv.duv_uvmirror", text="Mirror X", icon="MOD_MIRROR")
+        op = row.operator("dream_uv.uvmirror", text="Mirror X", icon="MOD_MIRROR")
         op.direction = "x"
-        op = row.operator("uv.duv_uvmirror", text="Mirror Y")
+        op = row.operator("dream_uv.uvmirror", text="Mirror Y")
         op.direction = "y"
 
         # pixel snap not functional in 2.8
@@ -171,13 +171,13 @@ class DUV_UVPanel(bpy.types.Panel):
         #col = box.column(align=True)
         col.label(text="Move to UV Edge:")
         row = col.row(align = True)
-        op = row.operator("uv.duv_uvmovetoedge", text=" ", icon="TRIA_UP_BAR")
+        op = row.operator("dream_uv.uvmovetoedge", text=" ", icon="TRIA_UP_BAR")
         op.direction="up"
-        op = row.operator("uv.duv_uvmovetoedge", text=" ", icon="TRIA_DOWN_BAR")
+        op = row.operator("dream_uv.uvmovetoedge", text=" ", icon="TRIA_DOWN_BAR")
         op.direction="down"
-        op = row.operator("uv.duv_uvmovetoedge", text=" ", icon="TRIA_LEFT_BAR")
+        op = row.operator("dream_uv.uvmovetoedge", text=" ", icon="TRIA_LEFT_BAR")
         op.direction = "left"
-        op = row.operator("uv.duv_uvmovetoedge", text=" ", icon="TRIA_RIGHT_BAR")
+        op = row.operator("dream_uv.uvmovetoedge", text=" ", icon="TRIA_RIGHT_BAR")
         op.direction = "right"
 
         box = layout.box()
@@ -185,7 +185,7 @@ class DUV_UVPanel(bpy.types.Panel):
 
 
         col.label(text="Unwrapping Tools:")
-        col.operator("uv.duv_uvunwrapsquare", text="Square Fit Unwrap", icon="OUTLINER_OB_LATTICE")
+        col.operator("dream_uv.uvunwrapsquare", text="Square Fit Unwrap", icon="OUTLINER_OB_LATTICE")
         unwraptool=col.operator("uv.unwrap", text="Blender Unwrap", icon='UV')
         unwraptool.method='CONFORMAL'
         unwraptool.margin=0.001
@@ -202,9 +202,9 @@ class DUV_UVPanel(bpy.types.Panel):
         row.prop(context.scene, "uvtransferxmax", text="")
         row.prop(context.scene, "uvtransferymax", text="")
 
-        col.operator("uv.duv_uvtransfergrab", text="Grab UV from selection", icon="FILE_TICK")
+        col.operator("dream_uv.uvtransfergrab", text="Grab UV from selection", icon="FILE_TICK")
         row = col.row(align = True)
-        row.operator("uv.duv_uvtransfer", text="Transfer to selection", icon="MOD_UVPROJECT")
+        row.operator("dream_uv.uvtransfer", text="Transfer to selection", icon="MOD_UVPROJECT")
         #col.label(text="top right coord:")
         #row = col.row(align = True)
         
@@ -220,7 +220,7 @@ class DUV_UVPanel(bpy.types.Panel):
         row.label(text="Atlas Object:")
         row.prop_search(context.scene, "subrect_atlas", context.scene, "objects", text="", icon="MOD_MULTIRES")
         col.separator()
-        col.operator("uv.duv_hotspotter", text="HotSpot", icon="SHADERFX")
+        col.operator("dream_uv.hotspotter", text="HotSpot", icon="SHADERFX")
 
         col = self.layout.column(align = True)
         #col.enabled = True
@@ -236,23 +236,23 @@ def prefs():
 
 classes = (
     DUVUVToolsPreferences,
-    DUV_UVPanel,
-    DUV_UVTranslate.UVTranslate,
-    DUV_UVTranslate.UVTranslateStep,
-    DUV_UVRotate.UVRotate,
-    DUV_UVRotate.UVRotateStep,
-    DUV_UVScale.UVScale,
-    DUV_UVScale.UVScaleStep,
-    DUV_UVExtend.UVExtend,
-    DUV_UVStitch.UVStitch,
-    DUV_UVTransfer.UVTransfer,
-    DUV_UVTransfer.UVTransferGrab,
-    DUV_UVCycle.UVCycle,
-    DUV_UVMirror.UVMirror,
-    DUV_UVMoveToEdge.UVMoveToEdge,
-    DUV_UVProject.UVProject,
-    DUV_UVUnwrap.UVUnwrapSquare,
-    DUV_HotSpot.HotSpotter,
+    DREAMUV_PT_uv,
+    DUV_UVTranslate.DREAMUV_OT_uv_translate,
+    DUV_UVTranslate.DREAMUV_OT_uv_translate_step,
+    DUV_UVRotate.DREAMUV_OT_uv_rotate,
+    DUV_UVRotate.DREAMUV_OT_uv_rotate_step,
+    DUV_UVScale.DREAMUV_OT_uv_scale,
+    DUV_UVScale.DREAMUV_OT_uv_scale_step,
+    DUV_UVExtend.DREAMUV_OT_uv_extend,
+    DUV_UVStitch.DREAMUV_OT_uv_stitch,
+    DUV_UVTransfer.DREAMUV_OT_uv_transfer,
+    DUV_UVTransfer.DREAMUV_OT_uv_transfer_grab,
+    DUV_UVCycle.DREAMUV_OT_uv_cycle,
+    DUV_UVMirror.DREAMUV_OT_uv_mirror,
+    DUV_UVMoveToEdge.DREAMUV_OT_uv_move_to_edge,
+    DUV_UVProject.DREAMUV_OT_uv_project,
+    DUV_UVUnwrap.DREAMUV_OT_uv_unwrap_square,
+    DUV_HotSpot.DREAMUV_OT_hotspotter,
 )
 
 def register():


### PR DESCRIPTION
It seems like there is a lot here but it is mainly just renaming classes & bl_idnames to better naming conventions which requires touching every file.

Classes were renamed to remove the _PT suffix error.

bl_idnames were renamed to better reflect where they come from when using the Blender search function:

Before
![Screenshot_1](https://user-images.githubusercontent.com/31065180/88814434-1669a080-d188-11ea-91ce-a692e027ba6d.png)
![Screenshot_2](https://user-images.githubusercontent.com/31065180/88814494-2d0ff780-d188-11ea-870e-aa27907bbf3d.png)

After
![Screenshot_3](https://user-images.githubusercontent.com/31065180/88814519-36995f80-d188-11ea-8e09-66a506630baf.png)
![Screenshot_4](https://user-images.githubusercontent.com/31065180/88814543-3c8f4080-d188-11ea-8838-b321c5006275.png)

Code in the __init__ was commented out to hide the 'Preferences:' pop-up even though nothing followed it, as shown in this screenshot now missing:

![Screenshot_5](https://user-images.githubusercontent.com/31065180/88814557-3f8a3100-d188-11ea-97c5-1636c04f0d60.png)