### PR TITLE
Fix for Blender 3.0 #18

### DIFF
--- a/DUV_UVCycle.py
+++ b/DUV_UVCycle.py
@@ -51,5 +51,5 @@ class DREAMUV_OT_uv_cycle(bpy.types.Operator):
                     loop[uv_layer].uv.x += xmin
                     loop[uv_layer].uv.y += ymin                
 
-        bmesh.update_edit_mesh(mesh, False, False)
+        bmesh.update_edit_mesh(mesh, loop_triangles=False, destructive=False)
         return {'FINISHED'}

--- a/DUV_UVExtend.py
+++ b/DUV_UVExtend.py
@@ -131,6 +131,6 @@ class DREAMUV_OT_uv_extend(bpy.types.Operator):
             l[uv_layer].uv.y += oy
             
         #bm.to_mesh(me)           
-        bmesh.update_edit_mesh(mesh, False, False)
+        bmesh.update_edit_mesh(mesh, loop_triangles=False, destructive=False)
 
         return {'FINISHED'}

--- a/DUV_UVInset.py
+++ b/DUV_UVInset.py
@@ -190,7 +190,7 @@ class DREAMUV_OT_uv_inset(bpy.types.Operator):
                         vert[self.bm.loops.layers.uv.active].uv.y=((deltay)*self.bm2.faces[i].loops[o][self.bm2.loops.layers.uv.active].uv.y)+((1-(deltay))*self.ycenter)
 
             #update mesh
-            bmesh.update_edit_mesh(self.mesh, False, False)
+            bmesh.update_edit_mesh(self.mesh, loop_triangles=False, destructive=False)
 
         elif event.type == 'LEFTMOUSE':
             
@@ -207,7 +207,7 @@ class DREAMUV_OT_uv_inset(bpy.types.Operator):
                     for o,vert in enumerate(face.loops):
                         vert[self.bm.loops.layers.uv.active].uv = self.bm2.faces[i].loops[o][self.bm2.loops.layers.uv.active].uv
             #update mesh
-            bmesh.update_edit_mesh(self.mesh, False, False)
+            bmesh.update_edit_mesh(self.mesh, loop_triangles=False, destructive=False)
             return {'CANCELLED'}
 
         return {'RUNNING_MODAL'}
@@ -277,7 +277,7 @@ class DREAMUV_OT_uv_inset_step(bpy.types.Operator):
                     loop[uv_layer].uv.y += ymin
 
         #update mesh
-        bmesh.update_edit_mesh(mesh, False, False)
+        bmesh.update_edit_mesh(mesh, loop_triangles=False, destructive=False)
 
 
 

--- a/DUV_UVMirror.py
+++ b/DUV_UVMirror.py
@@ -58,5 +58,5 @@ class DREAMUV_OT_uv_mirror(bpy.types.Operator):
                     loop[uv_layer].uv.x += xmin
                     loop[uv_layer].uv.y += ymin                    
 
-        bmesh.update_edit_mesh(mesh, False, False)
+        bmesh.update_edit_mesh(mesh, loop_triangles=False, destructive=False)
         return {'FINISHED'}

--- a/DUV_UVMoveToEdge.py
+++ b/DUV_UVMoveToEdge.py
@@ -62,5 +62,5 @@ class DREAMUV_OT_uv_move_to_edge(bpy.types.Operator):
                             l[bm.loops.layers.uv.active].uv.x += xdist
                             l[bm.loops.layers.uv.active].uv.y += ydist
 
-        bmesh.update_edit_mesh(mesh, False, False)
+        bmesh.update_edit_mesh(mesh, loop_triangles=False, destructive=False)
         return {'FINISHED'}

--- a/DUV_UVRotate.py
+++ b/DUV_UVRotate.py
@@ -125,7 +125,7 @@ class DREAMUV_OT_uv_rotate(bpy.types.Operator):
                         vert[self.bm.loops.layers.uv.active].uv.y = math.sin(delta) * (px-self.xcenter) +  math.cos(delta) * (py-self.ycenter) + self.ycenter
 
             #update mesh
-            bmesh.update_edit_mesh(self.mesh, False, False)
+            bmesh.update_edit_mesh(self.mesh, loop_triangles=False, destructive=False)
 
         elif event.type == 'LEFTMOUSE':
             
@@ -149,7 +149,7 @@ class DREAMUV_OT_uv_rotate(bpy.types.Operator):
                         vert[self.bm.loops.layers.uv.active].uv.y = math.sin(delta) * (px-self.xcenter) +  math.cos(delta) * (py-self.ycenter) + self.ycenter
 
             #update mesh
-            bmesh.update_edit_mesh(self.mesh, False, False)
+            bmesh.update_edit_mesh(self.mesh, loop_triangles=False, destructive=False)
             return {'CANCELLED'}
 
         return {'RUNNING_MODAL'}
@@ -235,7 +235,7 @@ class DREAMUV_OT_uv_rotate_step(bpy.types.Operator):
 
 
         #update mesh
-        bmesh.update_edit_mesh(mesh, False, False)
+        bmesh.update_edit_mesh(mesh, loop_triangles=False, destructive=False)
 
 
 

--- a/DUV_UVScale.py
+++ b/DUV_UVScale.py
@@ -190,7 +190,7 @@ class DREAMUV_OT_uv_scale(bpy.types.Operator):
                         vert[self.bm.loops.layers.uv.active].uv.y=((deltay)*self.bm2.faces[i].loops[o][self.bm2.loops.layers.uv.active].uv.y)+((1-(deltay))*self.ycenter)
 
             #update mesh
-            bmesh.update_edit_mesh(self.mesh, False, False)
+            bmesh.update_edit_mesh(self.mesh, loop_triangles=False, destructive=False)
 
         elif event.type == 'LEFTMOUSE':
             
@@ -207,7 +207,7 @@ class DREAMUV_OT_uv_scale(bpy.types.Operator):
                     for o,vert in enumerate(face.loops):
                         vert[self.bm.loops.layers.uv.active].uv = self.bm2.faces[i].loops[o][self.bm2.loops.layers.uv.active].uv
             #update mesh
-            bmesh.update_edit_mesh(self.mesh, False, False)
+            bmesh.update_edit_mesh(self.mesh, loop_triangles=False, destructive=False)
             return {'CANCELLED'}
 
         return {'RUNNING_MODAL'}
@@ -311,7 +311,7 @@ class DREAMUV_OT_uv_scale_step(bpy.types.Operator):
 
 
         #update mesh
-        bmesh.update_edit_mesh(mesh, False, False)
+        bmesh.update_edit_mesh(mesh, loop_triangles=False, destructive=False)
 
 
 

--- a/DUV_UVTranslate.py
+++ b/DUV_UVTranslate.py
@@ -216,7 +216,8 @@ class DREAMUV_OT_uv_translate(bpy.types.Operator):
                     vert[self.bm.loops.layers.uv.active].uv = origin_uv + uv_offset
 
             # update mesh
-            bmesh.update_edit_mesh(self.mesh, False, False)
+            #bmesh.update_edit_mesh(self.mesh, loop_triangles=False, destructive=False)
+            bmesh.update_edit_mesh(self.mesh, loop_triangles=False, destructive=False)
 
         elif event.type == 'LEFTMOUSE':
             # finish up and make sure changes are locked in place
@@ -233,7 +234,8 @@ class DREAMUV_OT_uv_translate(bpy.types.Operator):
                         reset_uv = self.bm_orig.faces[i].loops[o][self.bm_orig.loops.layers.uv.active].uv
                         vert[self.bm.loops.layers.uv.active].uv = reset_uv
             # update mesh
-            bmesh.update_edit_mesh(self.mesh, False, False)
+            #bmesh.update_edit_mesh(self.mesh, loop_triangles=False, destructive=False)
+            bmesh.update_edit_mesh(self.mesh, loop_triangles=False, destructive=False)
             return {'CANCELLED'}
 
         return {'RUNNING_MODAL'}
@@ -275,7 +277,9 @@ class DREAMUV_OT_uv_translate_step(bpy.types.Operator):
                     loop[uv_layer].uv.y += ymove
 
         #update mesh
-        bmesh.update_edit_mesh(mesh, False, False)
+        #bmesh.update_edit_mesh(mesh, loop_triangles=False, destructive=False)
+        bmesh.update_edit_mesh(mesh, loop_triangles=False, destructive=False)
+        
 
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -4,10 +4,10 @@
 bl_info = {
     "name": "DreamUV",
     "category": "UV",
-    "author": "Bram Eulaers",
+    "author": "Bram Eulaers, Draise",
     "description": "Edit selected faces'UVs directly inside the 3D Viewport. WIP. Check for updates @leukbaars",
     "blender": (2, 90, 0),
-    "version": (0, 9)
+    "version": (0, 9, 1)
 }
 
 import bpy


### PR DESCRIPTION
## Issue
When trying to do certain operators, we had a 3 arguement for a 1 argument python error. 

## Fix:
In the addon, anywhere that says:
`mesh, False, False)`

Replace with 
`mesh, loop_triangles=False, destructive=False)`

This will fix it.

https://github.com/leukbaars/DreamUV/issues/18