### PR TITLE
3.1 compatibility

### DIFF
--- a/DUV_Utils.py
+++ b/DUV_Utils.py
@@ -614,7 +614,7 @@ def square_fit(context):
                         loop_uv.uv.x *= edge[0]
                         loop_uv.uv.y *= edge[1]
 
-        bmesh.update_edit_mesh(me, True)
+        bmesh.update_edit_mesh(me)
         bpy.ops.uv.select_all(action='SELECT')
         #expand middle verts
         bpy.ops.uv.minimize_stretch(iterations=100)   


### PR DESCRIPTION
In new 3.0 version, "bmesh.update_edit_mesh"  takes only 1 argument (me) and couldn't be both "me" and "True".
Deleted "True".